### PR TITLE
New function names for clarity

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -16,10 +16,10 @@ async function f () {
 
   const s = new Sema(13, { capacity: arr.length })
   await Promise.all(arr.map(async (elem) => {
-    await s.v()
+    await s.acquire()
     console.log(elem, s.nrWaiting())
     await new Promise((resolve) => setTimeout(resolve, getRnd(500, 3000)))
-    s.p()
+    s.release()
   }))
   console.log('hello')
 }

--- a/examples/pausing.js
+++ b/examples/pausing.js
@@ -23,11 +23,11 @@ function resume() {
 
 const s = new Sema(5, { pauseFn: pause, resumeFn: resume })
 async function parse(line) {
-  await s.v()
+  await s.acquire()
 
   console.log(line)
 
-  s.p()
+  s.release()
 }
 
 rl.on('line', (line) => {

--- a/examples/pooling.js
+++ b/examples/pooling.js
@@ -6,9 +6,9 @@ const redis = require('promise-redis')
 async function f () {
   const red = new Sema(3, { initFn: () => redis().createClient(process.env.REDIS_URL) })
 
-  const db = await red.v()
+  const db = await red.acquire()
   console.log(await db.get('id'))
-  red.p(db)
+  red.release(db)
 
   const dbs = await red.drain()
   dbs.map((db) => db.quit())

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare module 'async-sema' {
 
     v(): Promise<string>;
 
-    acquire(token?: string): void;
+    acquire(): Promise<string>;
     
     p(token?: string): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,10 +8,14 @@ declare module 'async-sema' {
     drain(): Promise<string[]>;
     
     nrWaiting(): number;
+
+    v(): Promise<string>;
+
+    acquire(token?: string): void;
     
     p(token?: string): void;
-    
-    v(): Promise<string>;
+
+    release(token?: string): void;
     
   }
   

--- a/index.js
+++ b/index.js
@@ -60,14 +60,14 @@ class Sema {
     })
   }
   async v () {
-    return acquire();
+    return this.acquire();
   }
 
   release (token) {
     this.releaseEmitter.emit('release', this.noTokens ? '1' : token)
   }
   p (token) {
-    return release(token)
+    return this.release(token)
   }
 
   drain () {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 // Native
 const EventEmitter = require('events')
+const util = require('util')
 
 // Packages
 const Deque = require('double-ended-queue')
@@ -83,4 +84,6 @@ class Sema {
   }
 }
 
+Sema.prototype.v = util.deprecate(Sema.prototype.v, '`v()` is deperecated; use `acquire()` instead')
+Sema.prototype.p = util.deprecate(Sema.prototype.p, '`p()` is deprecated; use `release()` instead')
 module.exports = Sema

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ class Sema {
     }
   }
 
-  async v () {
+  async acquire () {
     let token = this.free.pop()
 
     if (token) {
@@ -59,15 +59,21 @@ class Sema {
       this.waiting.push({ resolve, reject })
     })
   }
+  async v () {
+    return acquire();
+  }
 
-  p (token) {
+  release (token) {
     this.releaseEmitter.emit('release', this.noTokens ? '1' : token)
+  }
+  p (token) {
+    return release(token)
   }
 
   drain () {
     const a = new Array(this.nrTokens)
     for (let i = 0; i < this.nrTokens; i++) {
-      a[i] = this.v()
+      a[i] = this.acquire()
     }
     return Promise.all(a)
   }

--- a/rate-limit.js
+++ b/rate-limit.js
@@ -4,7 +4,7 @@ module.exports = function rateLimit(rps) {
   const sema = new Sema(rps);
 
   return async function rl() {
-    await sema.v();
-    setTimeout(() => sema.p(), 1000);
+    await sema.acquire();
+    setTimeout(() => sema.release(), 1000);
   }
 }


### PR DESCRIPTION
The function names `v()` and `p()` in this library were
accidentally reversed from the tradition. Since the function names
might be a bit confusing even if named correctly, we should rename
them as `acquire()` and `release()` but also provide the old names
for backwards compatibility.

Fixes #13