### PR TITLE
fix assertion for pauseFn & resumeFn

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,17 @@ const Deque = require('double-ended-queue')
 
 class ReleaseEmitter extends EventEmitter {}
 
+function isFn (x) {
+  return typeof x === 'function'
+}
+
 function defaultInit () {
   return '1'
 }
 
 class Sema {
   constructor (nr, { initFn = defaultInit, pauseFn, resumeFn, capacity = 10 } = {}) {
-    if (pauseFn ^ resumeFn) {
+    if (isFn(pauseFn) ^ isFn(resumeFn)) {
       throw new Error('pauseFn and resumeFn must be both set for pausing')
     }
 


### PR DESCRIPTION
Nice idea for utilizing `^`! But seems you didn't actually try it. 

For example, given:

```js
const a = null, b = () => {}
```

Directly `^` them:

```js
a ^ a // => 0
a ^ b // => 0
b ^ b // => 0
```

However, with extra `isFn` checks:

```js
const isFn = x => typeof x === 'function'

isFn(a) ^ isFn(a) // => 0
isFn(a) ^ isFn(b) // => 1
isFn(b) ^ isFn(b) // => 0
```
