### PR TITLE
Changes ECMAScript target to es5 to support older browsers

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedParameters": true,
     "outDir": "./lib",
     "strict": true,
-    "target": "ES2017",
+    "target": "ES5",
     "types": ["jest","node"],
     "typeRoots": [
       "./types",


### PR DESCRIPTION
We recently started using this library for a project and noticed it didn't work in IE11 because of the ECMAScript target.

I created this quick PR to fix that. Please let me know if you have any questions.