### PR TITLE
Updated ts-jest version to resolve dependencies conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint-staged": "8.1.3",
     "pre-commit": "1.2.2",
     "prettier": "1.16.4",
-    "ts-jest": "23.10.5",
+    "ts-jest": "24.0.2",
     "typescript": "3.3.3"
   },
   "pre-commit": "lint:staged",


### PR DESCRIPTION
The current set of devDependencies are not compatible with each other.

Reproduction Steps:
1. Clone https://github.com/zeit/async-sema.git
2. Run `npm install`
3. See the following warning message appear:
> npm WARN ts-jest@23.10.5 requires a peer of jest@>=22 <24 but none is installed. You must install peer dependencies yourself.

Reason:
- ts-jest@23.10.5 can only accept jest@<24 as peerDependency
- However, async-sema has jest@24.1.0 as devDependency

Solution:
Update ts-jest to ts-jest@24.0.2, which accepts jest@24 as peerDependency