### PR TITLE
feat: expose tryAcquire()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,11 @@ example before a process will terminate.
 Returns the number of callers waiting on the semaphore, i.e. the number of
 pending promises.
 
+#### tryAcquire()
+
+Attempt to acquire a token from the semaphore, if one is available immediately.
+Otherwise, return `undefined`.
+
 #### async acquire()
 
 Acquire a token from the semaphore, thus decrement the number of available

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,8 +171,12 @@ export class Sema {
 		}
 	}
 
+	tryAcquire(): any | undefined {
+		return this.free.pop();
+	}
+
 	async acquire(): Promise<any> {
-		let token = this.free.pop();
+		let token = this.tryAcquire();
 
 		if (token !== void 0) {
 			return token;

--- a/test/sema.test.ts
+++ b/test/sema.test.ts
@@ -29,6 +29,18 @@ test('nr of available semas seems correct', async () => {
 	expect(s.nrWaiting()).toEqual(0);
 });
 
+test('tryAcquire returns undefined', async () => {
+	const s = new Sema(2);
+
+	await s.acquire();
+	expect(s.tryAcquire()).toBeDefined();
+	expect(s.tryAcquire()).toBeUndefined();
+
+	s.release();
+	expect(s.tryAcquire()).toBeDefined();
+	expect(s.tryAcquire()).toBeUndefined();
+});
+
 test('Pausing works', () => {
 	const pauseFn = jest.fn();
 	const resumeFn = jest.fn();


### PR DESCRIPTION
Allow users to try and get a token, but don't require them to block if the lock would fail.

Maybe eventually this function would take a timeout, or could `setImmediate` itself; so maybe it should be `async` from the get-go? I went for the "fast" option of exposing exactly what it does.